### PR TITLE
Fix MySQL connection timeout issue

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
       - MYSQL_DATABASE=mpf
       - MYSQL_USER=mpf
       - MYSQL_PASSWORD=mpf
+    # https://github.com/docker-library/mariadb/issues/113
     command: [
       '--wait_timeout=28800',
     ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,9 @@ services:
       - MYSQL_DATABASE=mpf
       - MYSQL_USER=mpf
       - MYSQL_PASSWORD=mpf
+    command: [
+      '--wait_timeout=28800',
+    ]
     volumes:
       - mysql_data:/var/lib/mysql
     ports:


### PR DESCRIPTION
Fix connection timeout issue by changing Mysql timeout value. The default timeout value for the image is lower than it should be. Overriding this value to avoid connections being closed by mysql due to timeout. (https://github.com/docker-library/mariadb/issues/113)

This resolves the following issue: https://github.com/openmpf/openmpf/issues/655

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmpf/openmpf-docker/2)
<!-- Reviewable:end -->
