### PR TITLE
Remove qt from C++ executor and Python executor images

### DIFF
--- a/components/cpp_executor/Dockerfile
+++ b/components/cpp_executor/Dockerfile
@@ -70,7 +70,7 @@ WORKDIR $MPF_HOME
 RUN --mount=type=bind,from=openmpf_build,source=/build-artifacts/install/lib,target=/tmp/mpf-libs \
     cd /tmp/mpf-libs; \
     # component executor binary's dependencies
-    cp --preserve=links --no-dereference liblog4cxx* libactivemq-cpp* libQtCore* libapr* libXext* \
+    cp --preserve=links --no-dereference liblog4cxx* libactivemq-cpp* libapr* libXext* \
         /usr/lib64;
 
 # component executor binary

--- a/components/python_executor/Dockerfile
+++ b/components/python_executor/Dockerfile
@@ -65,7 +65,7 @@ RUN yum update --assumeyes; \
 RUN --mount=type=bind,from=openmpf_build,source=/build-artifacts/install/lib,target=/tmp/mpf-libs \
     cd /tmp/mpf-libs; \
     # component executor binary's dependencies
-    cp --preserve=links --no-dereference liblog4cxx* libactivemq-cpp* libQtCore* libapr* libXext* \
+    cp --preserve=links --no-dereference liblog4cxx* libactivemq-cpp* libapr* libXext* \
         /usr/lib64;
 
 ENV MPF_HOME /opt/mpf


### PR DESCRIPTION
Associated PRs:
- https://github.com/openmpf/openmpf/pull/1113
- https://github.com/openmpf/openmpf-docker/pull/96

Issues:
- https://github.com/openmpf/openmpf/issues/1104
- https://github.com/openmpf/openmpf/issues/585

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmpf/openmpf-docker/96)
<!-- Reviewable:end -->
