### PR TITLE
Use inline anchor definitions to simplify compose file.

### DIFF
--- a/docker-compose.components.yml
+++ b/docker-compose.components.yml
@@ -28,24 +28,18 @@
 
 version: '3.7'
 
-x-common-env-vars:
-  &common-env-vars
-  WFM_USER: ${WFM_USER}
-  WFM_PASSWORD: ${WFM_PASSWORD}
-
-x-common-deploy:
-  &common-deploy
-  mode: replicated
-  replicas: 2
-
 x-detection-component-base:
   &detection-component-base
-  environment: *common-env-vars
+  environment: &common-env-vars
+    WFM_USER: ${WFM_USER}
+    WFM_PASSWORD: ${WFM_PASSWORD}
   depends_on:
     - workflow-manager
   volumes:
     - shared_data:/opt/mpf/share
-  deploy: *common-deploy
+  deploy: &common-deploy
+    mode: replicated
+    replicas: 2
 
 
 services:


### PR DESCRIPTION
I was looking at the yaml documentation for something else and came across some examples of defining the nested/inline syntax for declaring anchors. This change doesn't effect the output of `docker-compose config`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmpf/openmpf-docker/106)
<!-- Reviewable:end -->
