### PR TITLE
Use registry auth when running `docker-compose build` so model images can be pulled.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -306,14 +306,16 @@ try {
                     componentComposeFiles += ":$customGpuOnlyComponentsComposeFile"
                     customComponentServices =
                             readYaml(text: shOutput("cat $customComponentsComposeFile")).services.keySet()
-                    customComponentServices += 
+                    customComponentServices +=
                             readYaml(text: shOutput("cat $customGpuOnlyComponentsComposeFile")).services.keySet()
                 }
 
                 runtimeComposeFiles = "docker-compose.core.yml:$componentComposeFiles:docker-compose.elk.yml"
 
                 withEnv(["TAG=$inProgressTag", "COMPOSE_FILE=$runtimeComposeFiles", 'COMPOSE_DOCKER_CLI_BUILD=1']) {
-                    sh "docker-compose build $commonBuildArgs --build-arg RUN_TESTS --parallel"
+                    docker.withRegistry("http://$dockerRegistryHostAndPort", dockerRegistryCredId) {
+                        sh "docker-compose build $commonBuildArgs --build-arg RUN_TESTS --parallel"
+                    }
 
                     def composeYaml = readYaml(text: shOutput('docker-compose config'))
                     addVcsRefLabels(composeYaml, openmpfRepo, openmpfDockerRepo)


### PR DESCRIPTION
Related issue: https://github.com/openmpf/openmpf/issues/1179
Related PR: https://github.com/openmpf/openmpf-components/pull/187

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmpf/openmpf-docker/121)
<!-- Reviewable:end -->
