### PR TITLE
Hotfix/byte buddy

### DIFF
--- a/integration_tests/docker-entrypoint.sh
+++ b/integration_tests/docker-entrypoint.sh
@@ -95,7 +95,8 @@ set +o errexit
 
 # Download any missing dependencies, such as those used for custom system tests, to prevent potential
 # download timeout issues later on that occur on some host networks.
-mvn org.apache.maven.plugins:maven-dependency-plugin:3.1.1:go-offline
+mvn org.apache.maven.plugins:maven-dependency-plugin:3.1.1:go-offline \
+    $MVN_OPTIONS $EXTRA_MVN_OPTIONS # Intentionally unquoted to allow variables to hold multiple flags.
 
 mvn verify -Pjenkins \
     -Dspring.profiles.active=docker,jenkins \

--- a/integration_tests/docker-entrypoint.sh
+++ b/integration_tests/docker-entrypoint.sh
@@ -93,6 +93,10 @@ set -o xtrace
 
 set +o errexit
 
+# Download any missing dependencies, such as those used for custom system tests, to prevent potential
+# download timeout issues later on that occur on some host networks.
+mvn org.apache.maven.plugins:maven-dependency-plugin:3.1.1:go-offline
+
 mvn verify -Pjenkins \
     -Dspring.profiles.active=docker,jenkins \
     -Dit.test=ITWebREST \

--- a/openmpf_build/Dockerfile
+++ b/openmpf_build/Dockerfile
@@ -159,7 +159,7 @@ WORKDIR /home/mpf/openmpf-projects/openmpf
 RUN --mount=type=cache,id=mvn_cache,target=/root/.m2/repository,sharing=private \
     --mount=type=tmpfs,target=/tmp \
     --mount=type=tmpfs,target=/root/.cache \
-    mvn package \
+    mvn install \
         -DskipTests -Dmaven.test.skip=true -DskipITs \
         -Dcomponents.build.components='' \
         -Dstartup.auto.registration.skip=false \


### PR DESCRIPTION
**Issues:**

Fix the following error that occurs on a clean build on some host networks:

```
Could not transfer artifact net.bytebuddy:byte-buddy:jar:1.10.17 from/to central (https://repo.maven.apache.org/maven2): Connection timed out -> [Help 1]
```

**Related PRs:**

- https://github.com/openmpf/openmpf/pull/1622

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmpf/openmpf-docker/180)
<!-- Reviewable:end -->
