### PR TITLE
Use `REDIS_HOST` as endpoint when checking redis connectivity at workflow_manager startup

### DIFF
--- a/workflow_manager/docker-entrypoint.sh
+++ b/workflow_manager/docker-entrypoint.sh
@@ -87,7 +87,7 @@ echo 'PostgreSQL is available'
 # Wait for Redis service.
 echo 'Waiting for Redis to become available ...'
 # From https://stackoverflow.com/a/39214806
-until [ +PONG = "$( (exec 8<>/dev/tcp/redis/6379 && echo -e 'PING\r\n' >&8 && head -c 5 <&8; exec 8>&-) 2>/dev/null )" ]; do
+until [ +PONG = "$( (exec 8<>/dev/tcp/$REDIS_HOST/6379 && echo -e 'PING\r\n' >&8 && head -c 5 <&8; exec 8>&-) 2>/dev/null )" ]; do
     echo 'Redis is unavailable. Sleeping.'
     sleep 5
 done


### PR DESCRIPTION
Fix #223 

Disclaimer: I haven't tested this yet